### PR TITLE
Do not hold packages on apt upgrade

### DIFF
--- a/scripts/powershell/system_update.ps1
+++ b/scripts/powershell/system_update.ps1
@@ -5,7 +5,7 @@ $WslDistro = "Ubuntu"
 function Get-WslUpdate {
     Write-Output "Updating $WslDistro packages"
     wsl -d $WslDistro -u root -e apt-get update -qq
-    wsl -d $WslDistro -u root -e apt-get upgrade -yq
+    wsl -d $WslDistro -u root -e apt-get upgrade --with-new-pkgs -yq
     # Check if it exited with a non-zero status
     if (!$?) {
         Write-Error "$WslDistro upgrade failed"


### PR DESCRIPTION
`--with-new-pkgs`
Allow installing new packages when used in conjunction with upgrade. This is useful if the update of a installed package requires new dependencies to be installed. Instead of holding the package back upgrade will upgrade the package and install the new dependencies. Note that upgrade with this option will never remove packages, only allow adding new ones. Configuration Item: APT::Get::Upgrade-Allow-New.