### PR TITLE
fix: change shortcut for display resolution toggle

### DIFF
--- a/scripts/autohotkey/ChangeResolution.ahk
+++ b/scripts/autohotkey/ChangeResolution.ahk
@@ -31,15 +31,15 @@ ChangeResolution(Screen_Width := 1920, Screen_Height := 1080, Color_Depth := 32)
     Return DllCall( "ChangeDisplaySettingsA", "Ptr",Device_Mode, "UInt",0 )
 }
 
-; Ctrl + Alt + 1
-^!1::
+; Ctrl + Alt + F1
+^!F1::
 {
     ChangeResolution(1920,1080,32)
     return
 }
 
-; Ctrl + Alt + 2
-^!2::
+; Ctrl + Alt + F2
+^!F2::
 {
     ChangeResolution(3440,1440,32)
     return


### PR DESCRIPTION
Ctrl + Alt + number conflicts with Windows Explorer view settings.